### PR TITLE
Switch to HTML scraping

### DIFF
--- a/main.js
+++ b/main.js
@@ -201,11 +201,8 @@ class ContentReviewLog {
         const liveRev = page.liveRevision;
         const curr = this._data[title];
 
-        // Save to cache
-        this._data[title] = {
-            rev,
-            status
-        };
+        let returnValue;
+        let shouldSave = true;
 
         if (curr) {
             if (
@@ -228,19 +225,28 @@ class ContentReviewLog {
             ) {
                 // that means memcache somehow screwed up.
                 // - Then log it, dummy
-                return;
-            }
-            if (
+                shouldSave = false;
+            } else if (
                 (curr.rev !== rev || curr.status !== status) &&
                 status !== 'unsubmitted'
             ) {
                 this._debug(`${title}: ${curr.rev} -> ${rev}, ${curr.status} -> ${status}`);
 
-                return [title, rev, status, liveRev];
+                returnValue = [title, rev, status, liveRev];
             }
         } else {
-            console.debug('Current revision is not cached.');
+            this._debug('Current revision is not cached.');
         }
+
+        // Save to cache
+        if (shouldSave) {
+            this._data[title] = {
+                rev,
+                status
+            };
+        }
+
+        return returnValue;
     }
     /**
      * Formats and posts the review status change to Discord.

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,6 +670,11 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        },
         "http-cache-semantics": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -866,9 +871,17 @@
             "dev": true
         },
         "node-fetch": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
+        "node-html-parser": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.0.2.tgz",
+            "integrity": "sha512-N2000Ho9dkabvRZcyiwm6zOpdiAzxAxcJ0Z0WNoh/yXHG0YCuiK2WpNQfN+9vheLNY/h/It11Gk7uwT4QTfk9Q==",
+            "requires": {
+                "he": "1.2.0"
+            }
         },
         "normalize-url": {
             "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dependencies": {
         "discord.js": ">=12.2.0",
         "got": ">=11.5.1",
+        "node-html-parser": "^2.0.2",
         "tough-cookie": ">=4.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
And a lot of tweaks to other parts of the code I was looking at that nobody asked for
- **Switch to HTML scraping**
    - Added `node-html-parser` for doing the heavy lifting
    - `mapRows` method for converting the list of rows into the cache object
    - The cache object structure is preserved for backwards compat (it's also just ideal for it to be an object you can look up with just the title)
- Got rid of `got`'s settings for response shape, use chaining promise methods (`.text()`)
- Import `fs/promises` instead of `fs.promises`
- DRYed the `_processPage` updating the cache object, not sure why you didn't lift it up before
- Don't use a function and the 2nd argument to `.map` to handle the `this` context; use an arrow function