### PR TITLE
remove console.log that snuck in

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,7 +66,6 @@ class ContentReviewLog {
                     type: 'json'
                 }
             })).default;
-            console.log(this._data);
         } catch (error) {
             console.info(
                 'No cache.json file found, data will be created from scratch.'


### PR DESCRIPTION
Remove console.log that snuck in during https://github.com/WikiaUsers/ContentReviewLog/commit/2139718acf59304c1aaa92ba0f45f6241ef0b824 when closing https://github.com/WikiaUsers/ContentReviewLog/pull/13 per kocka's request